### PR TITLE
Allow the default boot timeout to be changed

### DIFF
--- a/test/test_herder.py
+++ b/test/test_herder.py
@@ -61,6 +61,18 @@ class TestHerder(object):
         assert_false(ret)
         popen_mock.return_value.terminate.assert_called_once_with()
 
+    @patch('unicornherder.herder.subprocess.Popen')
+    @patch('unicornherder.herder.timeout')
+    def test_configurable_boot_timeout(self, timeout_mock, popen_mock):
+        popen_mock.return_value.pid = -1
+        timeout_mock.side_effect = fake_timeout_fail
+        h = Herder(boot_timeout=45)
+        popen_mock.return_value.poll.return_value = None
+        ret = h.spawn()
+        timeout_mock.assert_called_once_with(45)
+        assert_false(ret)
+        popen_mock.return_value.terminate.assert_called_once_with()
+
     @patch('unicornherder.herder.time.sleep')
     @patch('unicornherder.herder.psutil.Process')
     @patch('%s.open' % builtin_mod)

--- a/unicornherder/command.py
+++ b/unicornherder/command.py
@@ -16,6 +16,8 @@ parser.add_argument('-u', '--unicorn', default='gunicorn', metavar='TYPE',
                     help='The type of unicorn to manage (gunicorn, gunicorn_django, unicorn)')
 parser.add_argument('-p', '--pidfile', metavar='PATH',
                     help='Path to the pidfile that unicorn will write')
+parser.add_argument('-t', '--timeout', default=30, type=int, metavar='30', dest='boot_timeout',
+                    help='Timeout in seconds to start workers')
 parser.add_argument('-v', '--version', action='version', version=__version__)
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='Any additional arguments will be passed to unicorn/'

--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -44,7 +44,7 @@ class Herder(object):
 
     """
 
-    def __init__(self, unicorn='gunicorn', pidfile=None, args=''):
+    def __init__(self, unicorn='gunicorn', pidfile=None, boot_timeout=30, args=''):
         """
 
         Creates a new Herder instance.
@@ -61,6 +61,7 @@ class Herder(object):
         self.unicorn = unicorn
         self.pidfile = '%s.pid' % self.unicorn if pidfile is None else pidfile
         self.args = args
+        self.boot_timeout = boot_timeout
 
         try:
             COMMANDS[self.unicorn]
@@ -97,11 +98,11 @@ class Herder(object):
         MANAGED_PIDS.add(process.pid)
 
         try:
-            with timeout(30):
+            with timeout(self.boot_timeout):
                 process.wait()
         except TimeoutError:
-            log.error('%s failed to daemonize within 30 seconds. Sending TERM '
-                      'and exiting.', self.unicorn)
+            log.error('%s failed to daemonize within %s seconds. Sending TERM '
+                      'and exiting.', self.unicorn, self.boot_timeout)
             if process.poll() is None:
                 process.terminate()
             return False


### PR DESCRIPTION
For some Rails apps 30 seconds isn't enough if the app is being fully preloaded. These apps should be able to override the default 'failed to daemonize' error.

This override is provided as a `boot_timeout` `kwarg` to `Herder`, or via the `-t, --timeout` argument to the command line version.
