### PR TITLE
use correct flag for unicorn pidfile

### DIFF
--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -13,9 +13,9 @@ log = logging.getLogger(__name__)
 COMMANDS = {
     'unicorn': 'unicorn -D -P "{pidfile}" {args}',
     'unicorn_rails': 'unicorn_rails -D -P "{pidfile}" {args}',
-    'unicorn_bin': '{unicorn_bin} -D -P "{pidfile}" {args}'
+    'unicorn_bin': '{unicorn_bin} -D -P "{pidfile}" {args}',
     'gunicorn': 'gunicorn -D -p "{pidfile}" {args}',
-    'gunicorn_django': 'gunicorn_django -D -p "{pidfile}" {args}',
+    'gunicorn_django': 'gunicorn_django -D -p "{pidfile}" {args}'
 }
 
 MANAGED_PIDS = set([])


### PR DESCRIPTION
using a -p flag with Unicorn will cause leaking of TCP sockets

I will be opening a new PR in the very near future for a fully specified gunicorn as well...

sorry for the error :(
