### PR TITLE
Change URL, ensure guidelines conformity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Unicorn Herder
 ==============
 
-.. image:: https://secure.travis-ci.org/alphagov/unicornherder.png
-   :target: http://travis-ci.org/alphagov/unicornherder
+.. image:: https://secure.travis-ci.org/gds-operations/unicornherder.png
+   :target: http://travis-ci.org/gds-operations/unicornherder
 
 `Unicorn <http://unicorn.bogomips.org/>`_ and `Gunicorn
 <http://gunicorn.org/>`_ are awesome tools for people writing web services in
@@ -92,6 +92,11 @@ with Unicorn Herder is given below::
     #  . /var/venv/myapp/bin/activate
     #  exec unicornherder -- -w 4 -b "127.0.0.1:$PORT" myapp:app
     #end script
+
+Discussion
+----------
+
+You can discuss this tool with our open source mailing list: gds-operations-open-source@digital.cabinet-office.gov.uk
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author='Nick Stenning',
     author_email='nick@whiteink.com',
     maintainer='Government Digital Service',
-    url='https://github.com/alphagov/unicornherder',
+    url='https://github.com/gds-operations/unicornherder',
 
     description='Unicorn Herder: manage daemonized (g)unicorns',
     long_description=long_description,


### PR DESCRIPTION
Since we have now moved this repository from Alphagov to GDS Operations, we
should change the old URL to the new one, despite 301s existing, and ensure
we conform to our own guidelines for open-source projects (published at
http://gds-operations.github.io/guidelines/)
