### PR TITLE
Remove unicorn_rails -P {pidfile} flag

### DIFF
--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 COMMANDS = {
     'unicorn': 'unicorn -D -P "{pidfile}" {args}',
-    'unicorn_rails': 'unicorn_rails -D -P "{pidfile}" {args}',
+    'unicorn_rails': 'unicorn_rails -D {args}',
     'unicorn_bin': '{unicorn_bin} -D -P "{pidfile}" {args}',
     'gunicorn': 'gunicorn -D -p "{pidfile}" {args}',
     'gunicorn_django': 'gunicorn_django -D -p "{pidfile}" {args}',


### PR DESCRIPTION
`unicorn_rails` does not use the -P flag ([source](https://github.com/defunkt/unicorn/blob/master/bin/unicorn_rails#L78-L82)) to specify the location of its pid file
(it uses the accompanying configuration file). Unfortunately, including the -P
flag was causing `ENV['RAILS_RELATIVE_URL_ROOT']` to be overwritten with the
path to the unicorn pid (which is nonsensical).

It may be worthwhile to also remove the flags to the other unicorn commands as well, since those flags are deprecated ([source](https://github.com/defunkt/unicorn/blob/master/bin/unicorn#L70-L74)), and have unicornherder read the pidfile location from the accompanying unicorn configuration file (but that probably requires more code changes).
