### PR TITLE
Parameterise time to wait before killing old unicorns when reloading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ intended to be daemonized.
 
 Unicorn Herder *also* intercepts ``SIGHUP``, because this is the signal sent by
 Upstart when you call ``initctl reload``, and uses it to trigger a hot-reload of
-its Unicorn instance. This process will take two minutes, in order to give the
-new workers time to start up.
+its Unicorn instance. This process will take two minutes by default, in order to
+give the new workers time to start up.
 
 **NB**: There will be a period during hot-reload when requests are served by
 both old and new workers. This might have serious implications if you are

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,7 +1,7 @@
 import contextlib
 
-from nose.tools import *
-from mock import *
+from nose.tools import assert_equal, assert_false, assert_raises, assert_true
+from mock import call, patch, MagicMock
 
 @contextlib.contextmanager
 def fake_timeout_fail(*args, **kwargs):

--- a/unicornherder/command.py
+++ b/unicornherder/command.py
@@ -24,6 +24,9 @@ parser.add_argument('-p', '--pidfile', metavar='PATH',
                     help='Path to the pidfile that unicorn will write')
 parser.add_argument('-t', '--timeout', default=30, type=int, metavar='30', dest='boot_timeout',
                     help='Timeout in seconds to start workers')
+parser.add_argument('-o', '--overlap', default=120, type=int, metavar='120',
+                    dest='overlap',
+                    help='Time to wait before killing old unicorns when reloading')
 parser.add_argument('-v', '--version', action='version', version=__version__)
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='Any additional arguments will be passed to unicorn/'

--- a/unicornherder/command.py
+++ b/unicornherder/command.py
@@ -23,7 +23,7 @@ parser.add_argument('-g', '--gunicorn-bin', default=None, metavar='GUNICORN_BIN'
 parser.add_argument('-p', '--pidfile', metavar='PATH',
                     help='Path to the pidfile that unicorn will write')
 parser.add_argument('-t', '--timeout', default=30, type=int, metavar='30', dest='boot_timeout',
-                    help='Timeout in seconds to start workers')
+                    help='Time to wait for new processes to daemonize themselves')
 parser.add_argument('-o', '--overlap', default=120, type=int, metavar='120',
                     dest='overlap',
                     help='Time to wait before killing old unicorns when reloading')

--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -190,7 +190,7 @@ class Herder(object):
             MANAGED_PIDS.add(self.master.pid)
 
             if self.reloading:
-                _wait_for_workers(self.master, self.overlap)
+                _wait_for_workers(self.overlap)
                 _kill_old_master(old_master)
                 self.reloading = False
 
@@ -271,7 +271,7 @@ def _emergency_slaughter():
             pass
 
 
-def _wait_for_workers(process, overlap):
+def _wait_for_workers(overlap):
     # TODO: do something smarter here
     time.sleep(overlap)
 

--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -62,6 +62,7 @@ class Herder(object):
         pidfile      - path of the pidfile to write
                        (Default: gunicorn.pid or unicorn.pid depending on the value of
                         the unicorn parameter)
+        boot_timeout - how long to wait for the new process to daemonize itself
         args         - any additional arguments to pass to the unicorn executable
                        (Default: '')
 
@@ -276,6 +277,7 @@ def _wait_for_workers(process):
 
 
 def _kill_old_master(process):
+    # SIGWINCH tells the master to kill its workers:
     log.debug("Sending WINCH to old master (PID %s)", process.pid)
     process.send_signal(signal.SIGWINCH)
     time.sleep(1)

--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -277,7 +277,20 @@ def _wait_for_workers(overlap):
 
 
 def _kill_old_master(process):
-    # SIGWINCH tells the master to kill its workers:
+    """Shut down the old server gracefully.
+
+    There's a bit of extra complexity here, because Unicorn and Gunicorn handle
+    signals differently : both respond to SIGWINCH by gracefully stopping their
+    workers, but while Unicorn treats SIGQUIT as a graceful shutdown and
+    SIGTERM as a quick shutdown, Gunicorn reverses the meaning of these two.
+
+    <http://unicorn.bogomips.org/SIGNALS.html>
+    <http://gunicorn-docs.readthedocs.org/en/latest/signals.html>
+
+    We get around this by sending SIGWINCH first, giving the worker processes
+    some time to shut themselves down first.
+
+    """
     log.debug("Sending WINCH to old master (PID %s)", process.pid)
     process.send_signal(signal.SIGWINCH)
     time.sleep(1)


### PR DESCRIPTION
The default time (120 seconds) makes deploys take longer than necessary for most of our applications, and tempts us to start post-deploy testing while old unicorns are still alive. This makes it possible to avoid those sources of sadness. We've left the default as 120 seconds so that this isn't a breaking change.

This PR also includes some small bits of tidying up which we came across.

(Paired with @fatbusinessman :snake:)