### PR TITLE
Remove title case from log output

### DIFF
--- a/unicornherder/herder.py
+++ b/unicornherder/herder.py
@@ -159,7 +159,7 @@ class Herder(object):
         while True:
             if not self._loop_inner():
                 # The unicorn has died. So should we.
-                log.error('%s died. Exiting.', self.unicorn.title())
+                log.error('%s died. Exiting.', self.unicorn)
                 return 1
             time.sleep(2)
 
@@ -176,14 +176,14 @@ class Herder(object):
             return False
 
         if old_master is None:
-            log.info('%s booted (PID %s)', self.unicorn.title(), self.master.pid)
+            log.info('%s booted (PID %s)', self.unicorn, self.master.pid)
 
             MANAGED_PIDS.add(self.master.pid)
 
         # Unicorn has forked a new master
         if old_master is not None and self.master.pid != old_master.pid:
             log.info('%s changed PID (was %s, now %s)',
-                     self.unicorn.title(),
+                     self.unicorn,
                      old_master.pid,
                      self.master.pid)
 


### PR DESCRIPTION
`self.unicorn` is a string which is either the path to the unicorn binary, the path to the gunicorn binary or the string 'gunicorn'. We call `title()` on the string which outputs something like this:

```
INFO      /Opt/Ruby/Bundle/Ruby/1.9.1/Bin/Unicorn booted (PID 10489)
```

Fixes #28.