### PR TITLE
Support .2 pidfiles for Gunicorn

### DIFF
--- a/test/test_pidfile.py
+++ b/test/test_pidfile.py
@@ -18,6 +18,12 @@ class TestPidfile(unittest.TestCase):
             file.flush()
             assert Pidfile(file.name[:-7]).pid == 123
 
+    def test_second_gunicorn_pidfile_exists(self):
+        with tempfile.NamedTemporaryFile(suffix='.2') as file:
+            file.write('123\n')
+            file.flush()
+            assert Pidfile(file.name[:-2]).pid == 123
+
     def test_pidfile_doesnt_exist(self):
         with self.assertRaises(PidfileError):
             Pidfile('file-does-not-exist').pid

--- a/test/test_pidfile.py
+++ b/test/test_pidfile.py
@@ -1,0 +1,23 @@
+import tempfile
+import unittest
+
+from unicornherder.pidfile import Pidfile, PidfileError
+
+
+class TestPidfile(unittest.TestCase):
+
+    def test_pidfile_exists(self):
+        with tempfile.NamedTemporaryFile() as file:
+            file.write('123\n')
+            file.flush()
+            assert Pidfile(file.name).pid == 123
+
+    def test_oldbin_pidfile_exists(self):
+        with tempfile.NamedTemporaryFile(suffix='.oldbin') as file:
+            file.write('123\n')
+            file.flush()
+            assert Pidfile(file.name[:-7]).pid == 123
+
+    def test_pidfile_doesnt_exist(self):
+        with self.assertRaises(PidfileError):
+            Pidfile('file-does-not-exist').pid

--- a/unicornherder/pidfile.py
+++ b/unicornherder/pidfile.py
@@ -12,6 +12,7 @@ class Pidfile:
 
     def __init__(self, filename):
         self.filenames = [
+            '{filename}.2'.format(filename=filename),
             filename,
             '{filename}.oldbin'.format(filename=filename)
         ]

--- a/unicornherder/pidfile.py
+++ b/unicornherder/pidfile.py
@@ -1,0 +1,34 @@
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class PidfileError(OSError):
+    pass
+
+
+class Pidfile:
+
+    def __init__(self, filename):
+        self.filenames = [
+            filename,
+            '{filename}.oldbin'.format(filename=filename)
+        ]
+
+    @property
+    def pid(self):
+        for filename in self.filenames:
+            pid = self.try_read_pidfile(filename)
+            if pid is not None:
+                return pid
+
+        raise PidfileError('Could not read pid from {filenames}'.format(filenames=self.filenames))
+
+    def try_read_pidfile(self, filename):
+        try:
+            return int(open(filename).read())
+        except IOError as error:
+            log.debug('Got IOError while attempting to read %s: %s', filename, error)
+        except ValueError as error:
+            log.debug('Got ValueError while attempting to parse %s: %s', filename, error)


### PR DESCRIPTION
When a new gunicorn process spawns, a new pidfile with a suffix of `.2` is created to contain the new PID. We need to be able to read from that file so we can read the new PID of the master process and correctly shut down the old process.

Note that this is different to unicorn which instead writes the PID to the existing file and writes a new file with the suffix of `.oldbin` which will contain the old PID.

Documentation for gunicorn: https://gunicorn-docs.readthedocs.io/en/latest/signals.html

> First, replace the old binary with a new one, then send a USR2 signal to the current master process. It executes a new binary whose PID file is postfixed with .2 (e.g. /var/run/gunicorn.pid.2), which in turn starts a new master process and new worker processes.

Documentation for unicorn: https://bogomips.org/unicorn/SIGNALS.html

> If you're using a pid file, the old process will have ".oldbin" appended to its path.

Without this, unicornherder spawns the new processes without ever closing down the old processes because it doesn't know the master has changed.

I've also refactored how pidfiles are read for clarity.

[Trello Card](https://trello.com/c/5dck6lSA/927-figure-out-why-staging-mapit-isnt-deploying-cleanly-%F0%9F%A6%84)