### PR TITLE
add some CI testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.7", "3.9", "pypy3.9"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 tox
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: "Test with tox and cpython"
+      if: "${{ !startsWith( matrix.python-version, 'pypy' )  }}"
+      run: |
+        tox -e "py$(echo ${{ matrix.python-version }} | tr -d .)"
+    - name: "Test with tox and pypy"
+      if: "${{ startsWith( matrix.python-version, 'pypy')  }}"
+      run: |
+        tox -e pypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psutil
+tox


### PR DESCRIPTION
This adds some basic CI testing to the repo. We are planning to contribute to this repo in the future a bit and some testing would be nice.

Next steps would be:

* fix linting, maybe use black for the codebase?
* migrate testing to pytest
* add an [additional timeout option](https://github.com/bgruening/unicornherder/tree/max_worker_wait_time) for workers that take longer than 2min to start
* some more documentation for systemd and supervisord users