### PR TITLE
Add --max-worker-wait-time parameter

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.7", "3.9", "pypy3.9"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 tox
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: "Test with tox and cpython"
+      if: "${{ !startsWith( matrix.python-version, 'pypy' )  }}"
+      run: |
+        tox -e "py$(echo ${{ matrix.python-version }} | tr -d .)"
+    - name: "Test with tox and pypy"
+      if: "${{ startsWith( matrix.python-version, 'pypy')  }}"
+      run: |
+        tox -e pypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psutil
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, pypy
+envlist = py27, py37, py39, pypy
 
 [testenv]
 deps =

--- a/unicornherder/command.py
+++ b/unicornherder/command.py
@@ -27,8 +27,8 @@ parser.add_argument('-t', '--timeout', default=30, type=int, metavar='30', dest=
 parser.add_argument('-o', '--overlap', default=30, type=int, metavar='30',
                     dest='overlap',
                     help='Time to wait before killing old unicorns when reloading')
-parser.add_argument('--max-worker-time-wait', default=120, type=int, metavar='120',
-                    dest='max_worker_time_wait',
+parser.add_argument('--max-worker-wait-time', default=120, type=int, metavar='120',
+                    dest='max_worker_wait_time',
                     help='Time to wait for workers to come up again')
 parser.add_argument('-v', '--version', action='version', version=__version__)
 parser.add_argument('args', nargs=argparse.REMAINDER,

--- a/unicornherder/command.py
+++ b/unicornherder/command.py
@@ -27,6 +27,9 @@ parser.add_argument('-t', '--timeout', default=30, type=int, metavar='30', dest=
 parser.add_argument('-o', '--overlap', default=30, type=int, metavar='30',
                     dest='overlap',
                     help='Time to wait before killing old unicorns when reloading')
+parser.add_argument('--max-worker-time-wait', default=120, type=int, metavar='120',
+                    dest='max_worker_time_wait',
+                    help='Time to wait for workers to come up again')
 parser.add_argument('-v', '--version', action='version', version=__version__)
 parser.add_argument('args', nargs=argparse.REMAINDER,
                     help='Any additional arguments will be passed to unicorn/'


### PR DESCRIPTION
This PR add a new parameter called `--max-worker-wait-time` which makes the time to wait for workers to come up again configurable.


This PR is based ontop of https://github.com/alphagov/unicornherder/pull/37 for GA based testing. You can see that testing works and passed here: https://github.com/bgruening/unicornherder/pull/1